### PR TITLE
Bug fixes on Python type matching of node IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ logs
 results
 work
 
+*.DS_Store
+
 # Generated Files
 *.png
 *.csv

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -13,12 +13,17 @@ miscellaneous:
 
 secnet:
   out_dir: "out/secnet/"
-  base_transformer_id: 000000000000
   secnet_args:
     separation: 50.0
     penalty: 0.5
     max_rating: 25000
     max_hops: 10
+    solver: scip
+    solver_parameters:
+      verbose: true
+      time_limit: 600
+      warm_start: true
+      relative_gap: 0.05
 
 primnet:
   out_dir: "out/primnet/"
@@ -31,6 +36,7 @@ primnet:
     maximum_branch_flow: 400
     max_feeder_number: 10
     max_feeder_capacity: 400
+    solver: scip
     relative_gap: 0.05
     verbose: true
     warm_start: true

--- a/utils/primnet_utils.py
+++ b/utils/primnet_utils.py
@@ -163,7 +163,8 @@ class PrimaryNetworkGenerator:
         self,
         sub: Substation,
         assignment: Dict[str, Dict],
-        config: PrimaryNetworkConfig
+        config: PrimaryNetworkConfig,
+        solver:str='scip'
         ):
         
         # get the combined road and transformer network mapped to the substation
@@ -182,7 +183,7 @@ class PrimaryNetworkGenerator:
             graph = nx.subgraph(self.candidate_graph, list(nodelist))
         
             # solve for optimal network
-            result, feeder_nodes = optimize_primary_network(graph, config)
+            result, feeder_nodes = optimize_primary_network(graph, solver, config)
             
             for n in feeder_nodes:
                 result.add_edge(

--- a/utils/secnet_utils.py
+++ b/utils/secnet_utils.py
@@ -150,6 +150,8 @@ class SecondaryNetworkGenerator:
         penalty = kwargs.get("penalty", 0.5)
         max_rating = kwargs.get("max_rating", 25e3)
         max_hops = kwargs.get("max_hops", 10)
+        solver = kwargs.get("solver", "scip")
+        solver_params = kwargs.get("solver_parameters", {})
 
         # Generate candidate network
         graph, road_nodes = create_candidate_network(
@@ -163,7 +165,9 @@ class SecondaryNetworkGenerator:
             graph=graph,
             penalty=penalty,
             max_rating=max_rating,
-            max_hops=max_hops
+            max_hops=max_hops,
+            solver=solver,
+            **solver_params
         )
         
         # Process and save results


### PR DESCRIPTION
Fixed bugs associated with
1. Feeder node not found: primarily arising because of int and str type feeder node
2. Base transformer ID removed as input parameter. Uses region and state to construct base transformer ID 